### PR TITLE
Custom exceptions with parameter/secret name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
   <properties>
     <!-- Increment major version for breaking changes -->
-    <major-version>1</major-version>
+    <major-version>2</major-version>
     <revision>${major-version}.local-SNAPSHOT</revision>
 
     <java.version>1.8</java.version>

--- a/src/main/kotlin/no/liflig/properties/GriidPropertiesFetcher.kt
+++ b/src/main/kotlin/no/liflig/properties/GriidPropertiesFetcher.kt
@@ -10,16 +10,19 @@ class GriidPropertiesFetcher {
     private val serializer = JsonElement.serializer()
     private val json = Json {}
 
+    @Throws(PropertyLoadingException::class)
     fun forPrefix(ssmPrefix: String): Properties =
         Properties().apply {
             putAll(parametersByPath(ssmPrefix))
             putAll(secretsByPath(ssmPrefix))
         }
 
+    @Throws(ParameterLoadingException::class, SecretLoadingException::class)
     private fun parametersByPath(path: String): Map<String, String> =
         AwsClientHelper.getParametersByPath("$path/config/")
             .mapKeys { (key, _) -> key.removePrefix("$path/config/") }
 
+    @Throws(ParameterLoadingException::class, SecretLoadingException::class)
     private fun secretsByPath(path: String): Map<String, String> =
         AwsClientHelper.getParametersByPath("$path/secrets/")
             .flatMap { (parameterKey, parameterValue) ->

--- a/src/main/kotlin/no/liflig/properties/PropertiesLoader.kt
+++ b/src/main/kotlin/no/liflig/properties/PropertiesLoader.kt
@@ -22,10 +22,17 @@ private val logger = LoggerFactory.getLogger(PropertiesLoader::class.java)
  * will be loaded before overrides.properties.
  *
  * All sources are optional.
+ *
+ * @throws PropertyLoadingException when it fails to load a property, for example
+ * when a secret ([SecretLoadingException]) or SSM parameter ([ParameterLoadingException]) is invalid.
+ * This exception has multiple subclasses, for finer grained catching.
  */
+@Throws(PropertyLoadingException::class)
+@Suppress("unused" /* This is the entry point for library consumers. */)
 fun loadProperties() = loadPropertiesInternal()
 
 // For testing
+@Throws(PropertyLoadingException::class)
 internal fun loadPropertiesInternal(
     applicationProperties: String = "application.properties",
     applicationTestProperties: String = "application-test.properties",
@@ -44,6 +51,7 @@ internal fun loadPropertiesInternal(
         }
         .also { logger.info("Loaded ${it.size} properties in total") }
 
+@Throws(PropertyLoadingException::class)
 private fun fromParameterStore(
     griidPropertiesFetcher: GriidPropertiesFetcher,
     getenv: (String) -> String?

--- a/src/main/kotlin/no/liflig/properties/PropertyLoadingException.kt
+++ b/src/main/kotlin/no/liflig/properties/PropertyLoadingException.kt
@@ -1,0 +1,4 @@
+package no.liflig.properties
+
+open class PropertyLoadingException(message: String, cause: Throwable?) :
+    RuntimeException(message, cause)


### PR DESCRIPTION
This change tries to make debugging easier, in the cases where secrets are missing in production and the developer has to guess which secret it is.