### PR TITLE
Add missing distributionManagent config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,13 @@
     <tag>HEAD</tag>
   </scm>
 
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <url>https://maven.pkg.github.com/capralifecycle/liflig-properties</url>
+    </repository>
+  </distributionManagement>
+
   <properties>
     <!-- Increment major version for breaking changes -->
     <major-version>2</major-version>


### PR DESCRIPTION
This was done inline in the previous CI-configuration

https://github.com/capralifecycle/liflig-properties/blob/b126b0c3ecbda73ddc78dd613cf1f50a932d2a4c/.github/workflows/ci.yml#L78-L79