### PR TITLE
Optionally load properties from environment

### DIFF
--- a/src/main/kotlin/no/liflig/properties/PropertiesLoader.kt
+++ b/src/main/kotlin/no/liflig/properties/PropertiesLoader.kt
@@ -22,7 +22,9 @@ private val log = getLogger {}
  * before `overrides.properties`.
  *
  * if [environmentPrefix] is non-null, then environment variables are loaded as properties before
- * properties from AWS Parameter Store.
+ * properties from AWS Parameter Store. Note that passing secrets as environment variables has
+ * security implications since the environment is easily accessible, and passing secrets via files
+ * or reading them directly from a secrets manager is preferred.
  *
  * All sources are optional.
  *


### PR DESCRIPTION
Adds an optional argument `environmentPrefix` to `loadProperties`. If this variable is non-null, environment variables are filtered and parsed as properties, so the variable `PREFIX_APP_CFG` is loaded as the property `app.cfg`. Setting the prefix to an empty string will load all environment variables as properties.

The precedence of this loader is set fairly low, so environment variables will override `application.properties`, but be overridden by values from SSM Parameter Store or `overrides.properties`.

This change allows the user to pass configuration through normal environment variables, which is an attractive option for containerized services running in Docker or ECS.